### PR TITLE
6 running tailwind building does not work out of the box

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -67,6 +67,15 @@ run "npm install --prefix $SCRIPT_DIR"
 	run "npx tailwindcss -i static/bib/tailwind.css -o static/bib/tailwind.dist.css"
 )
 
+(
+
+	cd "$SCRIPT_DIR/apps/dmad_on_django"
+	yellow "[dmad_on_django] Installing npm packages..."
+	run "npm install"
+	yellow "[dmad_on_django] Compiling Tailwind CSS..."
+	run "npx tailwindcss -i static/dmad_on_django/tailwind.css -o static/dmad_on_django/tailwind.dist.css"
+)
+
 yellow "Installing python dependencies..."
 run "$SCRIPT_DIR/bin/pip install -r $SCRIPT_DIR/python_requirements.txt"
 

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -5,3 +5,5 @@ django-debug-toolbar
 pyzotero
 iso639
 pylobid
+haystack
+django-htmx


### PR DESCRIPTION
I fixed the bug and added some missing requirements of dmad_on_django to the python_requirements.
When running migrate it still misses some o hystacks submodules
